### PR TITLE
Another version using a python library for the POST

### DIFF
--- a/py2sms.py
+++ b/py2sms.py
@@ -7,22 +7,18 @@
 #                                                     
                                                    
 
-import subprocess
-import os
+import requests
+# 'pip install requests' to install this library
 
 def sms(pnumber,msg):
-    sysmsg = 'curl http://textbelt.com/text -d number=' + str(pnumber) + ' -d ' + '\"message=' + str(msg) + '\"'
-    os.system(sysmsg)
-    #subprocess.call(sysmsg.split(' '))
-    ##subprocess.check_output returns a string of output of the command too
-    ##useful if you want to check the value returned to verify if the message sent
-    #output = subprocess.check_output(sysmsg.split(' '))
-    #if 'error' in output.lower():
-    #    print("Message: " + message + " failed to send to " + str(pnumber))
-    #elif 'false' in output.lower():
-    #    print("Message: " + message + " failed to send to " + str(pnumber))
-    #else:
+  addr = "http://textbelt.com/text"
+  number = str(pnumber)
+  message= str(msg)
+  r = requests.post(addr,data={'number' : number, 'message' = message})
+  if r.status_code == 200:
     print("Message: " + msg + " sent to phone number: " + str(pnumber))
+  else:
+    print("Message: " + msg + " failed to send to phone number: " + str(pnumber))
 
 # To send a text message call the function with
 # sms(phonenumber,'sending this text message')


### PR DESCRIPTION
Requires the simpler-to-use-than-urllib2-library requests to send the POST message instead.

This will instead be relient on an included library versus the system curl package being installed. 

Install requests using 'pip install requests'. It's one of many awesome python packages

<b>For Testing Purposes:</b>
You can clone my fork yourself and test from there to test it, then confirm the pull request if you're happy with it. 
